### PR TITLE
patch Greagan's Harp for EE 2.6.5.0 engine

### DIFF
--- a/rr/doc/readme_rr.html
+++ b/rr/doc/readme_rr.html
@@ -324,7 +324,7 @@
 </div>
 
 <div id="headerdiv-middle">
-  <span class="headerdiv-line">Author: aVENGER</span> | <span class="headerdiv-line"><a href="http://www.shsforums.net/forum/79-rogue-rebalancing/" target="_blank">Forum</a></span> | <span class="headerdiv-line"><a href="http://www.spellholdstudios.net/ie/rr" target="_blank">Mod homepage</a></span> | <span class="headerdiv-line">Version: 4.92</span>
+  <span class="headerdiv-line">Author: aVENGER</span> | <span class="headerdiv-line"><a href="http://www.shsforums.net/forum/79-rogue-rebalancing/" target="_blank">Forum</a></span> | <span class="headerdiv-line"><a href="http://www.spellholdstudios.net/ie/rr" target="_blank">Mod homepage</a></span> | <span class="headerdiv-line">Version: 4.93</span>
 </div>
 
 <div id="headerdiv-bottom">
@@ -569,6 +569,10 @@ in order to play this mod?</span><br />
     <a id="version" />
     <h4>Version History</h4>
     <div class="divimp">
+      <b>v4.93 - May 2, 2021</b><br />
+      <ul>
+        <li>Patch for EE 2.6.5.0 Engine</li>
+      </ul>
       <b>v4.92 - May 19, 2018</b><br />
       <ul>
         <li>Correctly patch Kiel's Buckler.</li>
@@ -767,7 +771,7 @@ in order to play this mod?</span><br />
     <br />
     <p class="faq-q"><a id="Translation_team" />Translation team:</p>
     <ul class="version-list">
-      <li>French Translation: Mornagest, Thot, Mathrim Cauthon, Lothringen, Maël and Graoumf (of the d'Oghmatiques)</li>
+      <li>French Translation: Mornagest, Thot, Mathrim Cauthon, Lothringen, Maï¿½l and Graoumf (of the d'Oghmatiques)</li>
       <li>Spanish Translation: Immortality, SirLancelot, Nieve, <a href="http://www.clandlan.net/" target="_blank">Clan DLAN</a>, Lisandro and Crevs Daak.</li>
       <li>German Translation: Cronox and Leomar</li>
       <li>Russian Translation: Alina, Pilferer, Fess, ATG, Vit MG and Tanger Soto of <a href="http://www.aerie.ru/" target="_blank">Aerie.ru</a> and Prowler, Hawkmoon, Njkzy, Silent and Ardanis of&nbsp;<a href="http://www.arcanecoast.ru/" target="_blank">Arcanecoast.ru</a></li>

--- a/rr/setup-rr.tp2
+++ b/rr/setup-rr.tp2
@@ -7,7 +7,7 @@
 
 BACKUP ~rr/backup~
 AUTHOR "Wisp, www.shsforums.net"
-VERSION ~v4.92~
+VERSION ~v4.93~
 
 ALWAYS
   INCLUDE ~rr/lib/rr#afix.tph~                                        // Include the Rogue Rebalancing Assorted Fixes macro
@@ -2258,7 +2258,7 @@ COPY_EXISTING ~%tutu_var%MISC2P.ITM~ override                // Greagan's Harp
       match_timing = 4 // delayed
       duration = 48
   END
-  LPF ALTER_EFFECT
+  /*LPF ALTER_EFFECT
     INT_VAR
       check_globals = 0
       check_headers = 1
@@ -2270,7 +2270,7 @@ COPY_EXISTING ~%tutu_var%MISC2P.ITM~ override                // Greagan's Harp
       duration = 1
     STR_VAR
       resource = ~SPNWCHRM~
-  END
+  END*/
 BUT_ONLY
 END // not on IWD:EE
 


### PR DESCRIPTION
Greagan's Harp is broken on EE 2.6.5.0. This request tries to fix that.